### PR TITLE
Windows: minimum fixes to build & run with VCPKG

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 # CMake build directories
 /cmake-build-debug/
 /cmake-build-release/
+/build
 
 # Build artifacts (object files, executables, libraries)
 *.o

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,12 @@ target_include_directories(imgui PUBLIC ${IMGUI_DIR}/backends)
 # Include directories for GLFW, needed by ImGui backend
 target_include_directories(imgui PRIVATE ${GLFW_DIR}/include)
 
+# GLFW
+add_library(GLFW_Intergrated INTERFACE)
+if (WIN32)
+find_package(glfw3 CONFIG REQUIRED)
+target_link_libraries(GLFW_Intergrated INTERFACE glfw)
+else ()
 # Add ImGui and GLFW
     # This tells CMake to:
         # 1. Enter the GLFW directory.
@@ -54,16 +60,37 @@ target_include_directories(imgui PRIVATE ${GLFW_DIR}/include)
         # 3. Build GLFW as part of our project.
     # *Find GLFW - This automatically finds the installed GLFW3 package, as it is installed system-wide (via: brew install glfw)
 find_package(GLFW3 REQUIRED)
+target_link_libraries(GLFW_Intergrated INTERFACE glfw)
+endif ()
 
+# GLEW
+add_library(GLEW_Intergrated INTERFACE)
+if (WIN32)
+find_package(GLEW REQUIRED)
+target_link_libraries(GLEW_Intergrated INTERFACE GLEW::GLEW)
+else ()
 # Add GLEW for OpenGL function loading
 find_library(GLEW_LIBRARIES NAMES GLEW REQUIRED)
-include_directories(${GLEW_INCLUDE_DIRS})
+target_include_directories(GLEW_Intergrated INTERFACE ${GLEW_INCLUDE_DIRS})
+target_link_libraries(GLEW_Intergrated INTERFACE ${GLEW_LIBRARIES})
+endif ()
 
+# OpenGL
+add_library(OpenGL_Intergrated INTERFACE)
+if (WIN32)
+find_package(OpenGL REQUIRED)
+target_link_libraries(OpenGL_Intergrated INTERFACE ${OPENGL_gl_LIBRARY})
+else ()
 # Link OpenGL (since it's required for your project)
 find_library(OpenGL_LIBRARY OpenGL)
+target_link_libraries(OpenGL_Intergrated INTERFACE ${OpenGL_LIBRARY})
+endif ()
 
-# Link the libraries (ImGui, GLFW, OpenGL and GLEW)
-target_link_libraries(FileExplorerMacOS PRIVATE imgui glfw ${OpenGL_LIBRARY} ${GLEW_LIBRARIES})
+target_link_libraries(imgui PUBLIC GLFW_Intergrated)
+target_link_libraries(imgui PUBLIC OpenGL_Intergrated)
+target_link_libraries(imgui PUBLIC GLEW_Intergrated)
+
+target_link_libraries(FileExplorerMacOS PRIVATE imgui)
 
 # Include directories for FileExplorerMacOS
 target_include_directories(FileExplorerMacOS PRIVATE ${GLFW_DIR}/include)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Description
 
 * Cross-Platform File Explorer app developed using ImGui and OpenGL in C++.
-In the current moment app works only on **macOS**, but will soon be available for both Windows and Linux.
+In the current moment app works only on **macOS**, but will soon be available for both Windows (see README_Windows.md) and Linux.
 
 ---
 

--- a/README_Windows.md
+++ b/README_Windows.md
@@ -1,0 +1,45 @@
+
+## Installation (Windows)
+
+[vcpkg](https://github.com/microsoft/vcpkg) is in use,
+see official guide for installation and integration with CMake -
+["Tutorial: Install and use packages with CMake"](https://learn.microsoft.com/en-us/vcpkg/get_started/get-started)
+
+In short, to have vcpkg:
+
+```
+git clone https://github.com/microsoft/vcpkg.git
+cd vcpkg
+bootstrap-vcpkg.bat
+```
+
+Next, vcpkg libraries are expected to be installed globally, for simplicity:
+
+```
+:: GLEW
+vcpkg install glew
+:: GLFW3
+vcpkg.exe install glfw3
+```
+
+## Build & run
+
+Assuming vcpkg is intalled into %VCPKG_ROOT%, just:
+
+```
+cmake -S . -B build ^
+    -DCMAKE_TOOLCHAIN_FILE=%VCPKG_ROOT%\scripts\buildsystems\vcpkg.cmake
+```
+
+To build (Release configuration):
+
+```
+cmake --build build --config Release
+```
+
+To run:
+
+```
+cd build
+Release\FileExplorerMacOS.exe
+```

--- a/h/DraggableIcon.h
+++ b/h/DraggableIcon.h
@@ -20,7 +20,7 @@ public:
     static float getHeight();
     bool renderIconWithName(bool render);
     static bool isFileOpened();
-    static bool setFileOpenedStatus(bool status);
+    static void setFileOpenedStatus(bool status);
 
 private:
     bool renderImageButton();

--- a/h/FileTree.h
+++ b/h/FileTree.h
@@ -5,6 +5,8 @@
 #ifndef TREE_H
 #define TREE_H
 
+#include <unordered_map>
+
 #include "TreeNode.h"
 
 class FileTree {

--- a/main.cpp
+++ b/main.cpp
@@ -59,8 +59,11 @@ static void glfw_error_callback(int error, const char* description)
 // Main code
 int main(int, char**)
 {
-
+#if (WIN32)
+    std::filesystem::directory_entry dirent(R"(C:\test)");
+#else
     std::filesystem::directory_entry dirent("/Users");
+#endif
     TreeNode root(dirent);
 
     FileTree::setRoot(root);
@@ -250,6 +253,7 @@ int main(int, char**)
     glfwDestroyWindow(window);
     glfwTerminate();
 
+    mapper.join();
 
     return 0;
 }

--- a/src/DraggableIcon.cpp
+++ b/src/DraggableIcon.cpp
@@ -75,7 +75,7 @@ bool DraggableIcon::isFileOpened() {
     return fileOpened;
 }
 
-bool DraggableIcon::setFileOpenedStatus(bool status) {
+void DraggableIcon::setFileOpenedStatus(bool status) {
     fileOpened = status;
 }
 

--- a/src/FileTree.cpp
+++ b/src/FileTree.cpp
@@ -30,7 +30,11 @@ void FileTree::populateFileMap() {
     try {
 
         // Populate the hashmap.
-        std::filesystem::directory_entry start_dir("/Users");
+#if (WIN32)
+        std::filesystem::directory_entry start_dir(R"(C:\test)");
+#else
+        std::filesystem::directory_entry dirent("/Users");
+#endif
         for (const auto& entry : std::filesystem::recursive_directory_iterator(start_dir)) {
 
             file_map[entry.path().filename().string()].push_back(entry.path());
@@ -39,6 +43,9 @@ void FileTree::populateFileMap() {
 
     } catch (const std::filesystem::filesystem_error& e) {
         std::cerr << "Error accessing entry: " << e.what() << std::endl;
+    }
+    catch (const std::exception& e) {
+        std::cerr << "Generic error accessing entry: " << e.what() << std::endl;
     }
 
     filesystemIndexed = true;
@@ -75,9 +82,13 @@ void FileTree::copyFile(TreeNode &dest) {
 }
 
 void FileTree::openFile(const std::string &filePath) {
+#if (WIN32)
+    system(filePath.c_str());
+#else
     /* Opens the file in a default program. */
     std::string command = "open \"" + filePath + "\"";
     system(command.c_str());
+#endif
 }
 
 void FileTree::deleteFile(TreeNode& toDelete) {

--- a/src/IconViewWindow.cpp
+++ b/src/IconViewWindow.cpp
@@ -16,7 +16,11 @@ std::stack<TreeNode*> IconViewWindow::nodeStack;
 bool IconViewWindow::goBack = false;
 std::string IconViewWindow::iconPath;
 bool IconViewWindow::lightTheme = true;
+#if (WIN32)
+std::string IconViewWindow::currentPath = R"(C:\test)";
+#else
 std::string IconViewWindow::currentPath = "/Users";
+#endif
 std::vector<std::string> IconViewWindow::prevPaths;
 
 void IconViewWindow::BeginRender() {
@@ -195,7 +199,11 @@ void IconViewWindow::Render() {
     // If the root icon is clicked, we push it onto the 'nodeStack'.
     if (clicked) {
         nodeStack.push(&root);
+#if (WIN32)
+        prevPaths.emplace_back(R"(C:\test)");
+#else
         prevPaths.emplace_back("/Users");
+#endif
         clicked = false;
     };
 }

--- a/src/SearchWindow.cpp
+++ b/src/SearchWindow.cpp
@@ -61,9 +61,9 @@ void DisplayQueryResults(const std::vector<std::filesystem::path>& filePaths, st
 
     for (auto& path : filePaths) {
         // Handle user interactions.
-        if (ImGui::Selectable(path.c_str())) {
+        if (ImGui::Selectable(path.string().c_str())) {
             // Store selected file path.
-            selectedFilePath = path;
+            selectedFilePath = path.string();
             ImGui::OpenPopup("SelectablePopup");
         }
     }


### PR DESCRIPTION
Hello,

Nice work! Wanted to show what it takes to run on Windows with minimal fixes, using VCPKG for packages management (see README_Windows.md):

```
:: GLEW
vcpkg install glew
:: GLFW3
vcpkg install glfw3
:: generate
cmake -S . -B build ^
    -DCMAKE_TOOLCHAIN_FILE=%VCPKG_ROOT%\scripts\buildsystems\vcpkg.cmake
:: build
cmake --build build --config Release
:: run
cd build
Release\FileExplorerMacOS.exe
```

Changes in CMake just use VCPKG for finding libraries. To abstract differences in a way packages are found on Windows (WIN32) and anywhere else, INTERFACE libraries are used. For instance, for GLEW:

```
# GLEW
add_library(GLEW_Intergrated INTERFACE)
if (WIN32)
  find_package(GLEW REQUIRED)
  target_link_libraries(GLEW_Intergrated INTERFACE GLEW::GLEW)
else ()
  # Add GLEW for OpenGL function loading
  find_library(GLEW_LIBRARIES NAMES GLEW REQUIRED)
  target_include_directories(GLEW_Intergrated INTERFACE ${GLEW_INCLUDE_DIRS})
  target_link_libraries(GLEW_Intergrated INTERFACE ${GLEW_LIBRARIES})
endif ()
```

basically, you can have virtual library (GLEW_Intergrated) with no actual sources, link and configure different other libraries (in a different way depending on platform). Later, just use it as "usual" library:

```
target_link_libraries(imgui PUBLIC GLFW_Intergrated)
```

Changes in the code are just:

1. replace hardcode of the path to something I had ("/Users" -> "C:\test") 
2. fix compilation: fs::path::c_str() has native `const wchar_t*` type, instead of `const char*`
3. fix opening file: just "file.txt" instead of "open file.txt"
4. add handling of exceptions: I have unicode file names that can't be converted to `const char*`, std::filesystem thows std::system_error

Probably, more needs to be fixed, but I was able to run and click over few folders:
<img width="639" alt="test" src="https://github.com/user-attachments/assets/261a9928-6f6c-409b-a495-cba394802dd8" />


Hope that helps